### PR TITLE
Feature/add new phone constraints

### DIFF
--- a/Constraints/BaseCustomPhoneNumber.php
+++ b/Constraints/BaseCustomPhoneNumber.php
@@ -7,11 +7,10 @@ namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
 use Symfony\Component\Validator\Constraint;
 
 /**
- * @Annotation
- * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
- * @deprecated
+ * Class BaseCustomPhoneNumber
+ * @package HalloVerden\ValidatorConstraintsBundle\Constraints
  */
-class Phone extends Constraint {
+abstract class BaseCustomPhoneNumber extends Constraint {
   const ERROR_INVALID_PHONE = 'caeb2f02-2af0-4af7-a15d-912d872e55ae';
 
   protected static $errorNames = [
@@ -20,14 +19,10 @@ class Phone extends Constraint {
 
   public $message = 'phoneNumber.invalid';
 
-  /**
-   * @var array|null
-   */
-  public $validTypes;
-
   public function __construct($options = null) {
-    $this->validTypes = $options['validTypes'] ?? null;
     parent::__construct($options);
   }
+
+  public abstract function getValidTypes(): ?array;
 
 }

--- a/Constraints/BaseCustomPhoneNumberValidator.php
+++ b/Constraints/BaseCustomPhoneNumberValidator.php
@@ -4,21 +4,16 @@
 namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
 
 use Symfony\Component\Validator\Constraint;
-use Symfony\Component\Validator\Constraints\GroupSequence;
-use Symfony\Component\Validator\Constraints\NotBlank;
 use Symfony\Component\Validator\ConstraintValidator;
 use Symfony\Component\Validator\ConstraintViolation;
 use Symfony\Component\Validator\ConstraintViolationListInterface;
 use Symfony\Component\Validator\Exception\UnexpectedTypeException;
 
 /**
- * Class PhoneValidator
+ * Class BaseCustomPhoneNumberValidator
  * @package HalloVerden\ValidatorConstraintsBundle\Constraints
- * @deprecated
  */
-class PhoneValidator extends ConstraintValidator {
-  const NOT_BLANK_GROUP = 'not_blank';
-  const PHONE_NUMBER_GROUP = 'phone_number';
+abstract class BaseCustomPhoneNumberValidator extends ConstraintValidator {
 
   /**
    * @var string
@@ -34,17 +29,16 @@ class PhoneValidator extends ConstraintValidator {
     $this->defaultRegion = $defaultRegion;
   }
 
-
   /**
    * @param mixed $value
    * @param Constraint $constraint
    */
   public function validate($value, Constraint $constraint) {
-    if (!$constraint instanceof Phone) {
-      throw new UnexpectedTypeException($constraint, Phone::class);
+    if (!$constraint instanceof BaseCustomPhoneNumber) {
+      throw new UnexpectedTypeException($constraint, BaseCustomPhoneNumber::class);
     }
     $value = (string)$value;
-    $violations = $this->context->getValidator()->validate($value, $this->getConstraints($constraint->validTypes), self::getGroupSequence());
+    $violations = $this->context->getValidator()->validate($value, $this->getConstraints($constraint->getValidTypes()));
     if ($violations->count() > 0) {
       self::addViolations($violations);
     }
@@ -52,13 +46,8 @@ class PhoneValidator extends ConstraintValidator {
 
   private function getConstraints(?array $validTypes) {
     return [
-      new NotBlank(['groups' => self::NOT_BLANK_GROUP]),
-      new PhoneNumber(['defaultRegion' => $this->defaultRegion, 'groups' => self::PHONE_NUMBER_GROUP, 'validTypes' => $validTypes]),
+      new PhoneNumber(['defaultRegion' => $this->defaultRegion, 'validTypes' => $validTypes]),
     ];
-  }
-
-  private static function getGroupSequence() {
-    return new GroupSequence([self::NOT_BLANK_GROUP, self::PHONE_NUMBER_GROUP]);
   }
 
   private function addViolations(ConstraintViolationListInterface $violations) {

--- a/Constraints/FixedLineOrMobilePhoneNumber.php
+++ b/Constraints/FixedLineOrMobilePhoneNumber.php
@@ -6,6 +6,11 @@ namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
 use libphonenumber\PhoneNumberType;
 
 /**
+ * Class FixedLineOrMobilePhoneNumber
+ * This Constraint is used to validate fixed line or mobile phone numbers
+ *
+ * @package HalloVerden\ValidatorConstraintsBundle\Constraints
+ *
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */

--- a/Constraints/FixedLineOrMobilePhoneNumber.php
+++ b/Constraints/FixedLineOrMobilePhoneNumber.php
@@ -1,0 +1,27 @@
+<?php
+
+
+namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
+
+use libphonenumber\PhoneNumberType;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+class FixedLineOrMobilePhoneNumber extends BaseCustomPhoneNumber {
+
+  /**
+   * @var array|null
+   */
+  public $validTypes;
+
+  public function __construct($options = null) {
+    $this->validTypes = [ PhoneNumberType::FIXED_LINE, PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE ];
+    parent::__construct($options);
+  }
+
+  public function getValidTypes(): ?array {
+    return $this->validTypes;
+  }
+}

--- a/Constraints/FixedLineOrMobilePhoneNumberValidator.php
+++ b/Constraints/FixedLineOrMobilePhoneNumberValidator.php
@@ -5,7 +5,7 @@ namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
 
 
 /**
- * Class BaseCustomPhoneNumberValidator
+ * Class FixedLineOrMobilePhoneNumberValidator
  * @package HalloVerden\ValidatorConstraintsBundle\Constraints
  */
 class FixedLineOrMobilePhoneNumberValidator extends BaseCustomPhoneNumberValidator {

--- a/Constraints/FixedLineOrMobilePhoneNumberValidator.php
+++ b/Constraints/FixedLineOrMobilePhoneNumberValidator.php
@@ -1,0 +1,13 @@
+<?php
+
+
+namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
+
+
+/**
+ * Class BaseCustomPhoneNumberValidator
+ * @package HalloVerden\ValidatorConstraintsBundle\Constraints
+ */
+class FixedLineOrMobilePhoneNumberValidator extends BaseCustomPhoneNumberValidator {
+
+}

--- a/Constraints/LooselyDefinedMobilePhoneNumber.php
+++ b/Constraints/LooselyDefinedMobilePhoneNumber.php
@@ -1,0 +1,28 @@
+<?php
+
+
+namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
+
+use libphonenumber\PhoneNumberType;
+
+/**
+ * @Annotation
+ * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
+ */
+class LooselyDefinedMobilePhoneNumber extends BaseCustomPhoneNumber {
+
+  /**
+   * @var array|null
+   */
+  public $validTypes;
+
+  public function __construct($options = null) {
+    $this->validTypes = [ PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE ];
+    parent::__construct($options);
+  }
+
+
+  public function getValidTypes(): ?array {
+    return $this->validTypes;
+  }
+}

--- a/Constraints/LooselyDefinedMobilePhoneNumber.php
+++ b/Constraints/LooselyDefinedMobilePhoneNumber.php
@@ -6,6 +6,11 @@ namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
 use libphonenumber\PhoneNumberType;
 
 /**
+ * Class LooselyDefinedMobilePhoneNumber
+ * This Constraint is used to validate mobile numbers or numbers where it's impossible to determine if they are fixed line or mobile
+ *
+ * @package HalloVerden\ValidatorConstraintsBundle\Constraints
+ *
  * @Annotation
  * @Target({"PROPERTY", "METHOD", "ANNOTATION"})
  */

--- a/Constraints/LooselyDefinedMobilePhoneNumberValidator.php
+++ b/Constraints/LooselyDefinedMobilePhoneNumberValidator.php
@@ -1,0 +1,12 @@
+<?php
+
+
+namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
+
+/**
+ * Class BaseCustomPhoneNumberValidator
+ * @package HalloVerden\ValidatorConstraintsBundle\Constraints
+ */
+class LooselyDefinedMobilePhoneNumberValidator extends BaseCustomPhoneNumberValidator {
+
+}

--- a/Constraints/LooselyDefinedMobilePhoneNumberValidator.php
+++ b/Constraints/LooselyDefinedMobilePhoneNumberValidator.php
@@ -4,7 +4,7 @@
 namespace HalloVerden\ValidatorConstraintsBundle\Constraints;
 
 /**
- * Class BaseCustomPhoneNumberValidator
+ * Class LooselyDefinedMobilePhoneNumberValidator
  * @package HalloVerden\ValidatorConstraintsBundle\Constraints
  */
 class LooselyDefinedMobilePhoneNumberValidator extends BaseCustomPhoneNumberValidator {

--- a/Constraints/Phone.php
+++ b/Constraints/Phone.php
@@ -19,4 +19,15 @@ class Phone extends Constraint {
   ];
 
   public $message = 'phoneNumber.invalid';
+
+  /**
+   * @var array|null
+   */
+  public $validTypes;
+
+  public function __construct($options = null) {
+    $this->validTypes = $options['validTypes'] ?? null;
+    parent::__construct($options);
+  }
+
 }

--- a/Constraints/PhoneNumber.php
+++ b/Constraints/PhoneNumber.php
@@ -77,7 +77,7 @@ class PhoneNumber extends Constraint {
       throw new \LogicException(sprintf('The "%s" class requires the "libphonenumber" component. Try running "composer require giggsey/libphonenumber-for-php".', self::class));
     }
 
-    $this->validTypes = [PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE];;
+    $options['validTypes'] = $this->validTypes = $options['validTypes'] ?? [PhoneNumberType::MOBILE, PhoneNumberType::FIXED_LINE_OR_MOBILE];
 
     parent::__construct($options);
   }

--- a/Constraints/PhoneNumberValidator.php
+++ b/Constraints/PhoneNumberValidator.php
@@ -26,8 +26,8 @@ class PhoneNumberValidator extends ConstraintValidator {
   /**
    * PhoneNumberValidator constructor.
    *
-   * @param string          $defaultRegion
-   * @param PhoneNumberUtil $phoneNumberUtil
+   * @param string $defaultRegion
+   * @param PhoneNumberUtil|null $phoneNumberUtil
    */
   public function __construct(string $defaultRegion = 'NO', ?PhoneNumberUtil $phoneNumberUtil = null) {
     if (!class_exists(PhoneNumberUtil::class)) {

--- a/Constraints/PhoneValidator.php
+++ b/Constraints/PhoneValidator.php
@@ -40,16 +40,16 @@ class PhoneValidator extends ConstraintValidator {
       throw new UnexpectedTypeException($constraint, Phone::class);
     }
     $value = (string)$value;
-    $violations = $this->context->getValidator()->validate($value, $this->getConstraints(), self::getGroupSequence());
+    $violations = $this->context->getValidator()->validate($value, $this->getConstraints($constraint->validTypes), self::getGroupSequence());
     if ($violations->count() > 0) {
       self::addViolations($violations);
     }
   }
 
-  private function getConstraints() {
+  private function getConstraints(?array $validTypes) {
     return [
       new NotBlank(['groups' => self::NOT_BLANK_GROUP]),
-      new PhoneNumber(['defaultRegion' => $this->defaultRegion, 'groups' => self::PHONE_NUMBER_GROUP]),
+      new PhoneNumber(['defaultRegion' => $this->defaultRegion, 'groups' => self::PHONE_NUMBER_GROUP, 'validTypes' => $validTypes]),
     ];
   }
 

--- a/DependencyInjection/HalloVerdenValidatorConstraintsExtension.php
+++ b/DependencyInjection/HalloVerdenValidatorConstraintsExtension.php
@@ -10,8 +10,10 @@ use Doctrine\Common\Annotations\Reader;
 use Doctrine\Persistence\ManagerRegistry;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\ArrayClassValidator;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\AssertIfValidator;
+use HalloVerden\ValidatorConstraintsBundle\Constraints\FixedLineOrMobilePhoneNumberValidator;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\IdenticalToValidator;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\KickboxValidator;
+use HalloVerden\ValidatorConstraintsBundle\Constraints\LooselyDefinedMobilePhoneNumberValidator;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\PhoneNumberValidator;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\PhoneValidator;
 use HalloVerden\ValidatorConstraintsBundle\Constraints\PropertyClassValidator;
@@ -95,6 +97,12 @@ class HalloVerdenValidatorConstraintsExtension extends Extension {
         '$defaultRegion' => $config['phone']['default_region']
       ]);
       $this->registerValidator($container, PhoneNumberValidator::class, [
+        '$defaultRegion' => $config['phone']['default_region']
+      ]);
+      $this->registerValidator($container, LooselyDefinedMobilePhoneNumberValidator::class, [
+        '$defaultRegion' => $config['phone']['default_region']
+      ]);
+      $this->registerValidator($container, FixedLineOrMobilePhoneNumberValidator::class, [
         '$defaultRegion' => $config['phone']['default_region']
       ]);
     }


### PR DESCRIPTION
Description: Added new Custom Constraints and Validators for `FixedLineOrMobilePhoneNumber` and `LooselyDefinedMobilePhoneNumber`, deprecated `Phone` Constraint and Validator
Depends on: https://github.com/halloverden/symfony-validator-constraints-bundle/pull/3